### PR TITLE
Added missing package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:2.7-alpine
 RUN apk update && \
-    apk add python python-dev libffi-dev gcc make musl-dev py-pip mysql-client git
+    apk add python python-dev libffi-dev gcc make musl-dev py-pip mysql-client git openssl-dev
 
 RUN mkdir -p /opt/CTFd
 RUN git clone https://github.com/CTFd/CTFd.git /opt/CTFd/


### PR DESCRIPTION
The packages  openssl-dev was missing. This made the installation of python library crashing 